### PR TITLE
JSONAPI Error objects are too restrictively typed

### DIFF
--- a/packages/starspot-core/src/json-api/index.ts
+++ b/packages/starspot-core/src/json-api/index.ts
@@ -65,30 +65,30 @@ namespace JSONAPI {
 
   export interface Error {
     /**  a unique identifier for this particular occurrence of the problem. */
-    id: ID;
+    id?: ID;
 
     /** a links object containing an `about` field */
-    links: LinksAbout;
+    links?: LinksAbout;
 
     /**  the HTTP status code applicable to this problem, expressed as a string value. */
-    status: string;
+    status?: string;
 
     /** an application-specific error code, expressed as a string value. */
-    code: string;
+    code?: string;
 
     /** a short, human-readable summary of the problem that SHOULD NOT change
      *  from occurrence to occurrence of the problem, except for purposes of
      *  localization. */
-    title: string;
+    title?: string;
 
     /** a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized. */
-    detail: string;
+    detail?: string;
 
     /**  an object containing references to the source of the error */
-    source: any;
+    source?: any;
 
     /** a meta object containing non-standard meta-information about the error. */
-    meta: any;
+    meta?: any;
   }
 }
 


### PR DESCRIPTION
According to http://jsonapi.org/format/#error-objects, all members are optional.

cc @tomdale 
