### PR TITLE
Relax restrictions on loading addons in prod until we have a build pi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
-dist
+./dist
+packages/*/dist
 lerna-debug.log

--- a/packages/starspot-cli/test/fixtures/in-app-addons-project-production/dist/addons/addon-a/index.ts
+++ b/packages/starspot-cli/test/fixtures/in-app-addons-project-production/dist/addons/addon-a/index.ts
@@ -1,0 +1,4 @@
+import Addon from "../../../../../../src/addon";
+
+export default class extends Addon {
+}

--- a/packages/starspot-cli/test/fixtures/in-app-addons-project-production/dist/addons/addon-b/index.ts
+++ b/packages/starspot-cli/test/fixtures/in-app-addons-project-production/dist/addons/addon-b/index.ts
@@ -1,0 +1,4 @@
+import Addon from "../../../../../../src/addon";
+
+export default class extends Addon {
+}

--- a/packages/starspot-cli/test/fixtures/in-app-addons-project-production/package.json
+++ b/packages/starspot-cli/test/fixtures/in-app-addons-project-production/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "in-app-addons-project",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
…peline

The current pipeline (`tsc`) removes `package.json` files in prod builds. This meant that addons were discovered but never loaded in production. Now we relax the check in production and load all addons in the addons directory.
