### PR TITLE
Add an optional "context" parameter to controller methods

### DIFF
--- a/packages/starspot-core/src/controller.ts
+++ b/packages/starspot-core/src/controller.ts
@@ -33,6 +33,7 @@ namespace Controller {
     response: Application.Response;
     action: string;
     controllerName: string;
+    context: Controller.Context = {};
 
     constructor(options: ParameterConstructorOptions) {
       this.request = options.request;
@@ -58,5 +59,12 @@ namespace Controller {
         return JSON.parse(data);
       });
     }
+  }
+
+  /**
+   * Dictionary allowing middleware/decorators to provide information to controllers alongside the JSON API payload
+   */
+  export interface Context {
+    [key: string]: any;
   }
 }


### PR DESCRIPTION
This allows middleware or decorators to include additional information alongside the JSONAPI payload
