### PR TITLE
Allow calling `await this.json()` multiple times

### DIFF
--- a/packages/starspot-core/src/controller.ts
+++ b/packages/starspot-core/src/controller.ts
@@ -35,6 +35,8 @@ namespace Controller {
     controllerName: string;
     context: Controller.Context = {};
 
+    _json: Promise<any>;
+
     constructor(options: ParameterConstructorOptions) {
       this.request = options.request;
       this.response = options.response;
@@ -43,6 +45,10 @@ namespace Controller {
     }
 
     json(): Promise<any> {
+      if (this._json) {
+        return this._json;
+      }
+
       let request = this.request;
       let body: Promise<string | Buffer>;
 
@@ -54,10 +60,12 @@ namespace Controller {
         return Promise.resolve(null);
       }
 
-      return body.then(data => {
+      this._json = body.then(data => {
         data = data.toString();
         return JSON.parse(data);
       });
+
+      return this._json;
     }
   }
 

--- a/packages/starspot-core/test/controller-test.ts
+++ b/packages/starspot-core/test/controller-test.ts
@@ -32,7 +32,7 @@ describe("ControllerParameters", function() {
     });
   });
 
-  it("parses JSON from the request if it is a readable stream", async function() {
+  describe("with a readable stream request", function () {
     let request: any = new Readable({
       read() {
         this.push(JSON.stringify({ "hello": "world" }));
@@ -45,10 +45,24 @@ describe("ControllerParameters", function() {
     let controllerName = "controllerName";
 
     let params = new Controller.Parameters({ request, response, action, controllerName });
-    let json = await params.json();
 
-    expect(json).to.deep.equal({
-      hello: "world"
+
+    it("parses JSON", async function() {
+      let json = await params.json();
+
+      expect(json).to.deep.equal({
+        hello: "world"
+      });
+    });
+
+    it("can parse multiple times", async function () {
+      await params.json();
+
+      let json = await params.json();
+
+      expect(json).to.deep.equal({
+        hello: "world"
+      });
     });
   });
 });


### PR DESCRIPTION
See https://github.com/stream-utils/raw-body/issues/33 for the details - once the stream is read, it'll hang if we try to read it again