### PR TITLE
Add documentation infrastructure

### DIFF
--- a/packages/starspot-docs/assets/book.css
+++ b/packages/starspot-docs/assets/book.css
@@ -1,0 +1,37 @@
+@import url('https://fonts.googleapis.com/css?family=Vollkorn');
+
+body, html {
+  margin: 0;
+  padding: 0;
+  font-family: Vollkorn;
+  font-size: 16px;
+}
+
+@media (min-width: 800px) {
+  body {
+    font-size: 18px;
+  }
+}
+
+@media (min-width: 1200px) {
+  body {
+    font-size: 20px;
+  }
+}
+
+#TOC {
+  position: fixed;
+  left: 0;
+}
+
+h1 {
+  font-size: 6.854em;
+  background: black;
+  color: white;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+}

--- a/packages/starspot-docs/assets/book.css
+++ b/packages/starspot-docs/assets/book.css
@@ -1,37 +1,143 @@
-@import url('https://fonts.googleapis.com/css?family=Vollkorn');
+@import url('https://fonts.googleapis.com/css?family=Vollkorn|Space+Mono');
+
+/* Type Scale
+3.998em
+2.827em
+1.999em
+1.414em
+1em
+0.707em
+0.5em
+0.354em
+*/
 
 body, html {
   margin: 0;
   padding: 0;
   font-family: Vollkorn;
+  color: #333;
+}
+
+html {
   font-size: 16px;
 }
 
-@media (min-width: 800px) {
-  body {
-    font-size: 18px;
-  }
-}
-
-@media (min-width: 1200px) {
-  body {
-    font-size: 20px;
-  }
-}
-
-#TOC {
-  position: fixed;
-  left: 0;
+h1, h2, h3, h4 {
+  line-height: 1em;
+  font-family: "Space Mono", monospace;
+  margin: 2rem 0 1.5rem;
 }
 
 h1 {
-  font-size: 6.854em;
-  background: black;
-  color: white;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0;
+  color: #5E548E;
+  font-size: 2.827em;
+}
+
+h2 {
+  color: #5E548E;
+  font-size: 1.999em;
+}
+
+h3 {
+  color: #9F86C0;
+  font-size: 1.414em;
+}
+
+h4 {
+  text-transform: uppercase;
+  font-size: 0.707em;
+  margin-bottom: 1rem;
+  color: #866cad;
+}
+
+p {
+  line-height: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+  box-shadow: inset 0 -5px 0 #E0B1CB;
+}
+
+a:hover {
+  border-bottom: 3px solid #5E548E;
+}
+
+main, nav {
+  margin-top: 1.414em;
+}
+
+nav {
+  margin: 2rem;
+}
+
+nav ul {
+  font-size: 1.0em;
+  list-style-type: none;
+  padding-left: 0;
+}
+
+nav ul li {
+  margin: 0.5em 0;
+}
+
+nav > ul > li {
+  margin-top: 0;
+}
+
+nav a {
+  font-family: "Space Mono", monospace;
+  color: #231942;
+  text-decoration: none;
+  box-shadow: inset 0 -5px 0 #E0B1CB;
+}
+
+nav ul ul {
+  padding-left: 1rem;
+}
+
+nav ul ul a {
+  font-size: 0.7em;
+  box-shadow: none;
+}
+
+main {
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+
+@media (min-width: 50em) {
+  html {
+    font-size: 2vw;
+  }
+}
+
+@media (min-width: 768px) {
+  header > h1 {
+    margin-top: 0;
+    letter-spacing: -0.05em;
+    word-spacing: -0.3em;
+  }
+
+  nav {
+    left: 0;
+    width: 14rem;
+  }
+
+  body {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 90em) {
+  main {
+    max-width: 32em;
+  }
+
+  html {
+    font-size: 1.8em;
+  }
 }

--- a/packages/starspot-docs/assets/listing.html
+++ b/packages/starspot-docs/assets/listing.html
@@ -1,0 +1,16 @@
+<html>
+  <body>
+    <h3>Operator Guide</h3>
+    <ul>
+      <li><a href="${REV}/operator-guide/index.html">HTML</a>
+      <li><a href="${REV}/operator-guide/operator-guide.pdf">PDF</a>
+      <li><a href="${REV}/operator-guide/operator-guide.epub">EPUB</a>
+    </ul>
+    <h3>Mechanic's Guide</h3>
+    <ul>
+      <li><a href="${REV}/mechanics-guide/index.html">HTML</a>
+      <li><a href="${REV}/mechanics-guide/mechanics-guide.pdf">PDF</a>
+      <li><a href="${REV}/mechanics-guide/mechanics-guide.epub">EPUB</a>
+    </ul>
+  </body>
+</html>

--- a/packages/starspot-docs/assets/template.html5
+++ b/packages/starspot-docs/assets/template.html5
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+$for(author-meta)$
+  <meta name="author" content="$author-meta$">
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$">
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style type="text/css">code{white-space: pre;}</style>
+$if(quotes)$
+  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+$endif$
+$if(highlighting-css)$
+  <style type="text/css">
+$highlighting-css$
+  </style>
+$endif$
+$for(css)$
+  <link rel="stylesheet" href="$css$">
+$endfor$
+$if(math)$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(toc)$
+<nav id="$idprefix$TOC">
+$toc$
+</nav>
+$endif$
+<main>
+$if(title)$
+<header>
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<p class="subtitle">$subtitle$</p>
+$endif$
+</header>
+$endif$
+$body$
+</main>
+$for(include-after)$
+$include-after$
+$endfor$
+</body>
+</html>

--- a/packages/starspot-docs/mechanics-guide/00-title.txt
+++ b/packages/starspot-docs/mechanics-guide/00-title.txt
@@ -1,0 +1,6 @@
+---
+title: "Starspot: A Mechanic's Guide"
+author: Tom Dale
+rights:  Creative Commons Non-Commercial Share Alike 3.0
+language: en-US
+---

--- a/packages/starspot-docs/mechanics-guide/01-introduction.md
+++ b/packages/starspot-docs/mechanics-guide/01-introduction.md
@@ -1,0 +1,7 @@
+# Starspot: Mechanic's Guide
+
+*Note: This guide covers the inner workings on Starspot. It is of primary
+interest to those working on the framework, addon authors, and advanced
+developers who want to understand what's happening under the hood. Newer
+developers interested in developing apps should consult the Operator Guide
+instead.*

--- a/packages/starspot-docs/operator-guide/00-title.txt
+++ b/packages/starspot-docs/operator-guide/00-title.txt
@@ -1,0 +1,6 @@
+---
+title: "Starspot Operator Guide"
+author: Tom Dale
+rights:  Creative Commons Non-Commercial Share Alike 3.0
+language: en-US
+---

--- a/packages/starspot-docs/operator-guide/01-introduction.md
+++ b/packages/starspot-docs/operator-guide/01-introduction.md
@@ -1,0 +1,80 @@
+# Starspot: Operator Guide
+
+Welcome to Starspot. Starspot is a Node.js framework for building web services.
+
+Out of the box, Starspot includes everything needed to be productive
+building modern web APIs, including:
+
+* SSL/TLS
+* HTTP2
+* Standardized JSON with [JSON:API][json-api]
+* Reading and writing to a database with [Knex][knex]
+* Scheduling background jobs
+* Automated unit and integration tests with [Mocha][mocha]
+
+[json-api]: http://jsonapi.org
+[knex]: http://knexjs.org
+[mocha]: https://mochajs.org
+
+However, Starspot is completely modular. You can remove or replace any of the
+built-in functionality and replace it with something better suited to your
+needs.
+
+## Philosophy
+
+### SSL First
+
+Today, there's no excuse for deploying new services without encryption.
+Unfortunately, most development tools make you jump through hoops to set up a
+local environment that works with SSL.
+
+Starspot makes SSL a first-class part of the development experience, automating
+the generation of certificates and the configuration of custom domains.
+
+### HTTP2 First
+
+HTTP2 can dramatically improve the performance of web services, allowing servers
+to deliver many items at once without the traditional limit on the number of
+concurrent requests. Starspot's routing layer supports HTTP2 out of the box,
+with fallback to HTTP 1.1 for older clients.
+
+### Database Agnostic
+
+Starspot ships with built-in support for SQL databases like MySQL and
+PostgreSQL. However, if you use something other than (or in addition to!) a SQL
+database, Starspot offers a pluggable interface for integrating any Node
+libraries into the greater Starspot architecture.
+
+## Installation
+
+To use Starspot, you will need Node v6 or later.
+
+Install Starspot globally using npm:
+
+```sh
+npm install starspot -g
+```
+
+Once finished, you can verify that it is working by running:
+
+```sh
+starspot --version
+```
+
+## Creating a New App
+
+To create a new Starspot application, use the `starspot new` command. For example,
+to create an app called `my-app`, run:
+
+```sh
+starspot new my-app
+```
+
+This will create a new directory called `my-app`. Inside the directory, you'll
+find that it has automatically configured the `package.json` to contain
+everything needed by a Starspot application, as well as a directory structure to
+help you organize your files.
+
+If you have `git` installed, Starspot will also automatically initialize your new application
+as a Git repository.
+

--- a/packages/starspot-docs/operator-guide/01-introduction.md
+++ b/packages/starspot-docs/operator-guide/01-introduction.md
@@ -1,6 +1,33 @@
-# Starspot: Operator Guide
+## Introduction
 
-Welcome to Starspot. Starspot is a Node.js framework for building web services.
+Welcome to Starspot. Starspot is a Node.js framework for building modern web
+services.
+
+This book will guide you through everything you need to know to build a web API
+using Starspot. It is designed for new learners who want pragmatic advice for
+quickly writing programs. You should have some knowledge of JavaScript and
+Node.js already.
+
+### Why Starspot?
+
+Starspot is designed for developers who want to be quickly productive working in
+Node.js. While JavaScript has grown into quite a capable language, the Node
+ecosystem still tends too much towards chaos. That flexibility is great when you
+need it, but getting started requires spending days deciding on which libraries
+to patch together. And don't even mention the maintenance nightmare inheriting
+someone else's code.
+
+Starspot is opinionated without relying on magic. Its modularity means you can
+pull out any piece that you find yourself fighting with, and replace it with
+something that works better for your needs.
+
+Starspot also believes 100% that client-side web and native applications are the
+future. It has no built-in support for templates or rendering HTML. Modern
+servers should be APIs, and only APIs. Starspot is dramatically simpler than
+legacy frameworks because it doesn't have to support hybrid API/HTML
+monstrosities.
+
+### Philosophy
 
 Out of the box, Starspot includes everything needed to be productive
 building modern web APIs, including:
@@ -20,9 +47,7 @@ However, Starspot is completely modular. You can remove or replace any of the
 built-in functionality and replace it with something better suited to your
 needs.
 
-## Philosophy
-
-### SSL First
+#### SSL First
 
 Today, there's no excuse for deploying new services without encryption.
 Unfortunately, most development tools make you jump through hoops to set up a
@@ -31,14 +56,14 @@ local environment that works with SSL.
 Starspot makes SSL a first-class part of the development experience, automating
 the generation of certificates and the configuration of custom domains.
 
-### HTTP2 First
+#### HTTP2 First
 
 HTTP2 can dramatically improve the performance of web services, allowing servers
 to deliver many items at once without the traditional limit on the number of
 concurrent requests. Starspot's routing layer supports HTTP2 out of the box,
 with fallback to HTTP 1.1 for older clients.
 
-### Database Agnostic
+#### Database Agnostic
 
 Starspot ships with built-in support for SQL databases like MySQL and
 PostgreSQL. However, if you use something other than (or in addition to!) a SQL
@@ -47,7 +72,15 @@ libraries into the greater Starspot architecture.
 
 ## Installation
 
-To use Starspot, you will need Node v6 or later.
+To use Starspot, you will need Node 6 or later. You can check which version of Node
+you have by running:
+
+```sh
+node --version
+```
+
+If you have a version of Node lower than 6.0.0, you can install a newer version from
+the [nodejs.org Download page](https://nodejs.org/en/download/).
 
 Install Starspot globally using npm:
 

--- a/packages/starspot-docs/package.json
+++ b/packages/starspot-docs/package.json
@@ -2,6 +2,7 @@
   "name": "starspot-docs",
   "version": "0.6.0",
   "scripts": {
-    "build": "./scripts/build-book.sh"
+    "build": "./scripts/build-book.sh",
+    "deploy": "npm run build && ./scripts/deploy.sh"
   }
 }

--- a/packages/starspot-docs/package.json
+++ b/packages/starspot-docs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "starspot-docs",
+  "version": "0.6.0",
+  "scripts": {
+    "build": "./scripts/build-book.sh"
+  }
+}

--- a/packages/starspot-docs/scripts/build-book.sh
+++ b/packages/starspot-docs/scripts/build-book.sh
@@ -3,6 +3,8 @@
 rm -rf dist
 mkdir dist
 
+ASSETS="../../assets"
+
 find_source_files() {
   echo "\033[34mBuilding ${1}\033[0m"
   SOURCE_FILES=`find ./$1 -iname "*.md"`
@@ -24,7 +26,16 @@ build_pdf() {
 build_html() {
   local html="${DIST}/${BOOK_NAME}.html"
   echo_file "html" "${html}"
-  pandoc --standalone --toc --css="../../assets/book.css" --output="${html}" $SOURCE_FILES
+
+  pandoc --to=html5 \
+    --template="assets/template.html5" \
+    --standalone \
+    --toc \
+    --toc-depth=3 \
+    --css="${ASSETS}/book.css" \
+    --output="${html}" \
+    --verbose \
+    "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
 }
 
 build_epub() {

--- a/packages/starspot-docs/scripts/build-book.sh
+++ b/packages/starspot-docs/scripts/build-book.sh
@@ -4,33 +4,40 @@ rm -rf dist
 mkdir dist
 
 find_source_files() {
+  echo "\033[34mBuilding ${1}\033[0m"
   SOURCE_FILES=`find ./$1 -iname "*.md"`
   DIST="dist/${1}"
   BOOK_NAME=$1
   mkdir $DIST
 }
 
+echo_file() {
+  printf '  %-14s-> \e[36m%s\e[0m\n' "Building ${1}" "${2}"
+}
+
 build_pdf() {
-  pandoc --standalone --smart -o "${DIST}/${BOOK_NAME}.pdf" $SOURCE_FILES
+  local pdf="${DIST}/${BOOK_NAME}.pdf"
+  echo_file "pdf" "${pdf}"
+  pandoc --standalone --smart --output="${pdf}" $SOURCE_FILES
 }
 
 build_html() {
-  pandoc --standalone -o "${DIST}/${BOOK_NAME}.html" $SOURCE_FILES
+  local html="${DIST}/${BOOK_NAME}.html"
+  echo_file "html" "${html}"
+  pandoc --standalone --toc --css="../../assets/book.css" --output="${html}" $SOURCE_FILES
 }
 
 build_epub() {
-  pandoc --standalone -o "${DIST}/${BOOK_NAME}.epub" "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
+  local epub="${DIST}/${BOOK_NAME}.epub"
+  echo_file "epub" "${epub}"
+  pandoc --standalone --output="${epub}" "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
 }
 
 for book in "operator-guide" "mechanics-guide"
 do
   find_source_files $book
-  build_pdf
   build_html
   build_epub
+  build_pdf
+  echo
 done
-
-# pandoc --standalone --smart -o ./dist/starspot-operators-guide.pdf $SOURCE_FILES
-# echo $SOURCE_FILES
-# find ./book \( -iname "*.md" -or -iname "*.txt" \) -exec pandoc --standalone --smart -o ./dist/starspot-operators-guide.pdf {} \+
-

--- a/packages/starspot-docs/scripts/build-book.sh
+++ b/packages/starspot-docs/scripts/build-book.sh
@@ -1,16 +1,63 @@
 #!/bin/sh
 
-rm -rf dist
-mkdir dist
+main() {
+  find_output_directory
+  rm -rf $DIST
+
+  for book in "operator-guide" "mechanics-guide"
+  do
+    find_source_files $book
+    build_html
+    build_epub
+    build_pdf
+    echo
+  done
+
+  build_index
+}
 
 ASSETS="../../assets"
+
+find_current_tag() {
+  echo "Looking for git tags pointing at HEAD..."
+
+  local tag_count=$(git tag --points-at HEAD | grep "v.*" | wc -l | bc)
+
+  if [ $tag_count -gt 1 ]
+  then
+    echo "\033[31mMore than one matching version tag:\n"
+    echo "$(git tag --points-at HEAD | grep "v.*")\n"
+    echo "Aborting"
+    exit 1
+  elif [ $tag_count -eq 1 ]
+  then
+    CURRENT_TAG=$(git tag --points-at HEAD | grep "v.*")
+  else
+    CURRENT_TAG=""
+  fi
+}
+
+find_output_directory() {
+  find_current_tag
+
+  if [ $CURRENT_TAG ]
+  then
+    echo "Found version tag \033[1;35m${CURRENT_TAG}\033[0m\n"
+    REV=$CURRENT_TAG}
+    DIST="dist/${CURRENT_TAG}"
+  else
+    REV=$(git rev-parse --short HEAD)
+    echo "No tag found for HEAD, using rev \033[1;35m${REV}\033[0m \n"
+    DIST="dist/${REV}"
+  fi
+}
 
 find_source_files() {
   echo "\033[34mBuilding ${1}\033[0m"
   SOURCE_FILES=`find ./$1 -iname "*.md"`
-  DIST="dist/${1}"
   BOOK_NAME=$1
-  mkdir $DIST
+  BOOK_DIST="${DIST}/${BOOK_NAME}"
+  mkdir -p $BOOK_DIST
 }
 
 echo_file() {
@@ -18,37 +65,37 @@ echo_file() {
 }
 
 build_pdf() {
-  local pdf="${DIST}/${BOOK_NAME}.pdf"
+  local pdf="${BOOK_DIST}/${BOOK_NAME}.pdf"
   echo_file "pdf" "${pdf}"
   pandoc --standalone --smart --output="${pdf}" $SOURCE_FILES
 }
 
 build_html() {
-  local html="${DIST}/${BOOK_NAME}.html"
+  local html="${BOOK_DIST}/index.html"
   echo_file "html" "${html}"
+
+  cp assets/book.css ${BOOK_DIST}/book.css
 
   pandoc --to=html5 \
     --template="assets/template.html5" \
     --standalone \
     --toc \
     --toc-depth=3 \
-    --css="${ASSETS}/book.css" \
+    --css="book.css" \
     --output="${html}" \
     --verbose \
     "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
 }
 
 build_epub() {
-  local epub="${DIST}/${BOOK_NAME}.epub"
+  local epub="${BOOK_DIST}/${BOOK_NAME}.epub"
   echo_file "epub" "${epub}"
   pandoc --standalone --output="${epub}" "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
 }
 
-for book in "operator-guide" "mechanics-guide"
-do
-  find_source_files $book
-  build_html
-  build_epub
-  build_pdf
-  echo
-done
+build_index() {
+  cp assets/listing.html dist/index.html
+  sed -e "s/\${REV}/${REV}/" assets/listing.html > dist/index.html
+}
+
+main

--- a/packages/starspot-docs/scripts/build-book.sh
+++ b/packages/starspot-docs/scripts/build-book.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+rm -rf dist
+mkdir dist
+
+find_source_files() {
+  SOURCE_FILES=`find ./$1 -iname "*.md"`
+  DIST="dist/${1}"
+  BOOK_NAME=$1
+  mkdir $DIST
+}
+
+build_pdf() {
+  pandoc --standalone --smart -o "${DIST}/${BOOK_NAME}.pdf" $SOURCE_FILES
+}
+
+build_html() {
+  pandoc --standalone -o "${DIST}/${BOOK_NAME}.html" $SOURCE_FILES
+}
+
+build_epub() {
+  pandoc --standalone -o "${DIST}/${BOOK_NAME}.epub" "${BOOK_NAME}/00-title.txt" $SOURCE_FILES
+}
+
+for book in "operator-guide" "mechanics-guide"
+do
+  find_source_files $book
+  build_pdf
+  build_html
+  build_epub
+done
+
+# pandoc --standalone --smart -o ./dist/starspot-operators-guide.pdf $SOURCE_FILES
+# echo $SOURCE_FILES
+# find ./book \( -iname "*.md" -or -iname "*.txt" \) -exec pandoc --standalone --smart -o ./dist/starspot-operators-guide.pdf {} \+
+

--- a/packages/starspot-docs/scripts/deploy.sh
+++ b/packages/starspot-docs/scripts/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+aws s3 sync dist/ s3://starspot.io

--- a/packages/starspot-docs/test.html
+++ b/packages/starspot-docs/test.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+  <title></title>
+  <style type="text/css">code{white-space: pre;}</style>
+  <style type="text/css">
+div.sourceCode { overflow-x: auto; }
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code > span.dt { color: #902000; } /* DataType */
+code > span.dv { color: #40a070; } /* DecVal */
+code > span.bn { color: #40a070; } /* BaseN */
+code > span.fl { color: #40a070; } /* Float */
+code > span.ch { color: #4070a0; } /* Char */
+code > span.st { color: #4070a0; } /* String */
+code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code > span.ot { color: #007020; } /* Other */
+code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code > span.fu { color: #06287e; } /* Function */
+code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+code > span.cn { color: #880000; } /* Constant */
+code > span.sc { color: #4070a0; } /* SpecialChar */
+code > span.vs { color: #4070a0; } /* VerbatimString */
+code > span.ss { color: #bb6688; } /* SpecialString */
+code > span.im { } /* Import */
+code > span.va { color: #19177c; } /* Variable */
+code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code > span.op { color: #666666; } /* Operator */
+code > span.bu { } /* BuiltIn */
+code > span.ex { } /* Extension */
+code > span.pp { color: #bc7a00; } /* Preprocessor */
+code > span.at { color: #7d9029; } /* Attribute */
+code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+</head>
+<body>
+<main>
+<h1 id="starspot-operator-guide">Starspot: Operator Guide</h1>
+<p>Welcome to Starspot. Starspot is a Node.js framework for building web services.</p>
+<p>Out of the box, Starspot includes everything needed to be productive building modern web APIs, including:</p>
+<ul>
+<li>SSL/TLS</li>
+<li>HTTP2</li>
+<li>Standardized JSON with <a href="http://jsonapi.org">JSON:API</a></li>
+<li>Reading and writing to a database with <a href="http://knexjs.org">Knex</a></li>
+<li>Scheduling background jobs</li>
+<li>Automated unit and integration tests with <a href="https://mochajs.org">Mocha</a></li>
+</ul>
+<p>However, Starspot is completely modular. You can remove or replace any of the built-in functionality and replace it with something better suited to your needs.</p>
+<h2 id="philosophy">Philosophy</h2>
+<h3 id="ssl-first">SSL First</h3>
+<p>Today, there's no excuse for deploying new services without encryption. Unfortunately, most development tools make you jump through hoops to set up a local environment that works with SSL.</p>
+<p>Starspot makes SSL a first-class part of the development experience, automating the generation of certificates and the configuration of custom domains.</p>
+<h3 id="http2-first">HTTP2 First</h3>
+<p>HTTP2 can dramatically improve the performance of web services, allowing servers to deliver many items at once without the traditional limit on the number of concurrent requests. Starspot's routing layer supports HTTP2 out of the box, with fallback to HTTP 1.1 for older clients.</p>
+<h3 id="database-agnostic">Database Agnostic</h3>
+<p>Starspot ships with built-in support for SQL databases like MySQL and PostgreSQL. However, if you use something other than (or in addition to!) a SQL database, Starspot offers a pluggable interface for integrating any Node libraries into the greater Starspot architecture.</p>
+<h2 id="installation">Installation</h2>
+<p>To use Starspot, you will need Node v6 or later.</p>
+<p>Install Starspot globally using npm:</p>
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash"><span class="kw">npm</span> install starspot -g</code></pre></div>
+<p>Once finished, you can verify that it is working by running:</p>
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash"><span class="kw">starspot</span> --version</code></pre></div>
+<h2 id="creating-a-new-app">Creating a New App</h2>
+<p>To create a new Starspot application, use the <code>starspot new</code> command. For example, to create an app called <code>my-app</code>, run:</p>
+<div class="sourceCode"><pre class="sourceCode sh"><code class="sourceCode bash"><span class="kw">starspot</span> new my-app</code></pre></div>
+<p>This will create a new directory called <code>my-app</code>. Inside the directory, you'll find that it has automatically configured the <code>package.json</code> to contain everything needed by a Starspot application, as well as a directory structure to help you organize your files.</p>
+<p>If you have <code>git</code> installed, Starspot will also automatically initialize your new application as a Git repository.</p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
This adds a build pipeline for building Markdown-based "books" into PDFs, HTML and epub.

Currently there are two "books," one focused on end developers and one for contributors that will describe the internals.