### PR TITLE
added the ability to ignore fields in update unless readonly attrs specified

### DIFF
--- a/packages/starspot-json-api/src/index.ts
+++ b/packages/starspot-json-api/src/index.ts
@@ -1,5 +1,5 @@
 export { default as ResourceController, after } from "./resource-controller";
-export { default as Resource, attribute, writable, attributes, writableAttributes, hasOne } from "./resource";
+export { default as Resource, attribute, writable, readOnly, attributes, writableAttributes, hasOne } from "./resource";
 export { default as Serializer } from "./serializer";
 export { default as JSONAPI } from "./json-api";
 export { JSONAPIError } from "./exceptions";

--- a/packages/starspot-json-api/src/operations/update-resource.ts
+++ b/packages/starspot-json-api/src/operations/update-resource.ts
@@ -35,7 +35,7 @@ function processAttributes(type: string, attributes: JSONAPI.AttributesObject, f
 
     if (fields.has(camelizedKey) && fields.get(camelizedKey).updatable) {
       processed[camelizedKey] = attributes[key];
-    } else {
+    } else if (fields.has(camelizedKey) && !fields.get(camelizedKey).ignoreUpdateErrors) {
       throw new AttributeNotUpdatableError(type, key);
     }
   }

--- a/packages/starspot-json-api/src/resource/decorators.ts
+++ b/packages/starspot-json-api/src/resource/decorators.ts
@@ -20,8 +20,20 @@ export function creatable(resource: Resource<any>, attribute: string) {
   fieldFor(resource, attribute, AttributeField).creatable = true;
 }
 
-export function readOnly(resource: Resource<any>, attribute: string) {
-  fieldFor(resource, attribute, AttributeField).writable = false;
+export function readOnly(resource: Resource<any> | any, attribute?: string | any): any {
+  if (arguments.length === 1) {
+    let options: any = resource;
+
+    return function (resource: Resource<any>, attribute: string) {
+      let field = fieldFor(resource, attribute, AttributeField);
+      field.writable = false;
+      field.ignoreUpdateErrors = options && options.ignoreWrites;
+    }
+  } else {
+    let field = fieldFor(resource, attribute, AttributeField);
+    field.writable = false;
+    field.ignoreUpdateErrors = false;
+  }
 }
 
 /*

--- a/packages/starspot-json-api/src/resource/fields.ts
+++ b/packages/starspot-json-api/src/resource/fields.ts
@@ -66,6 +66,7 @@ export class Field implements Descriptor {
 
   updatable = false;
   creatable = false;
+  ignoreUpdateErrors = false;
 
   get writable() {
     return this.updatable && this.creatable;
@@ -80,6 +81,8 @@ export class Field implements Descriptor {
     let desc = new (<any>this.constructor)(this.name);
     desc.updatable = this.updatable;
     desc.creatable = this.creatable;
+    desc.ignoreUpdateErrors = this.ignoreUpdateErrors;
+
     return desc;
   }
 }

--- a/packages/starspot-json-api/test/update-resource-test.ts
+++ b/packages/starspot-json-api/test/update-resource-test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import ResourceController, { after } from "../src/resource-controller";
-import Resource, { attribute, updatable, writableAttributes, updatableAttributes, creatableAttributes } from "../src/resource";
+import Resource, { attribute, updatable, readOnly, writableAttributes, updatableAttributes, creatableAttributes } from "../src/resource";
 import JSONAPI from "../src/json-api";
 
 import { createApplication, createResponse, createJSONRequest } from "starspot-test-core";
@@ -20,6 +20,14 @@ describe("Fetching Data", function () {
     @attribute
     @updatable
     src: string;
+
+    @attribute
+    @readOnly({ ignoreWrites: true })
+    fingerprint: string;
+
+    @attribute
+    @readOnly
+    superEmoInfo: string;
 
     async updateAttributes(attributes: Resource.Attributes) {
       Object.assign(this.model, attributes);
@@ -82,11 +90,114 @@ describe("Fetching Data", function () {
             "src": "http://example.com/images/productivity.png",
             "is-writable": true,
             "is-updatable": true,
-            "is-creatable": null
+            "is-creatable": null,
+            "fingerprint": null,
+            "super-emo-info": null
           }
         }
       });
 
+    });
+
+    it("ignores a field that is presented for update but that has `@readOnly({ignoreWrites: true})`", async function() {
+      class PhotoController extends ResourceController {
+        @after("update")
+        didUpdate(model: Photo) {
+          didUpdateWasCalled = true;
+          expect(model).to.be.an.instanceof(Photo);
+        }
+      }
+
+      let didUpdateWasCalled = false;
+
+      let app = await createApplication()
+        .routes(({ resources }) => {
+          resources("photos");
+        })
+        .controller("photo", PhotoController)
+        .register("resource", "photo", PhotoResource)
+        .boot();
+
+      let response = createResponse();
+      let request = createJSONAPIRequest("PATCH", "/photos/123", {
+        "data": {
+          "id": "1234",
+          "type": "photos",
+          "attributes": {
+            "title": "Ember Hamster",
+            "src": "http://example.com/images/productivity.png",
+            "is-writable": true,
+            "is-updatable": true,
+            "fingerprint": "jsfkjh342kjl234kl"
+          }
+        }
+      });
+
+      await app.dispatch(request, response);
+
+      expect(didUpdateWasCalled).to.be.true;
+      expect(response.statusCode).to.equal(200);
+      expect(response.getHeader("content-type")).to.equal("application/vnd.api+json");
+      expect(response.toJSON()).to.deep.equal({
+        data: {
+          "type": "photos",
+          "id": "1234",
+          "attributes": {
+            "title": "Ember Hamster",
+            "src": "http://example.com/images/productivity.png",
+            "is-writable": true,
+            "is-updatable": true,
+            "is-creatable": null,
+            "fingerprint": null,
+            "super-emo-info": null
+          }
+        }
+      });
+    });
+
+    it("returns an exception when a field that is presented for update that is set to `@readOnly()`", async function() {
+      class PhotoController extends ResourceController {
+        @after("update")
+        didUpdate(model: Photo) {
+          didUpdateWasCalled = true;
+          expect(model).to.be.an.instanceof(Photo);
+        }
+      }
+
+      let didUpdateWasCalled = false;
+
+      let app = await createApplication()
+        .routes(({ resources }) => {
+          resources("photos");
+        })
+        .controller("photo", PhotoController)
+        .register("resource", "photo", PhotoResource)
+        .boot();
+
+      let response = createResponse();
+      let request = createJSONAPIRequest("PATCH", "/photos/123", {
+        "data": {
+          "id": "1234",
+          "type": "photos",
+          "attributes": {
+            "title": "Ember Hamster",
+            "src": "http://example.com/images/productivity.png",
+            "is-writable": true,
+            "is-updatable": true,
+            "super-emo-info": "OMG don't touch me!!!!"
+          }
+        }
+      });
+
+      await app.dispatch(request, response);
+
+      expect(didUpdateWasCalled).to.be.false;
+
+      expect(response.statusCode).to.equal(422);
+      expect(response.getHeader("content-type")).to.equal("application/vnd.api+json");
+      expect(response.toJSON()).to.deep.equal({
+        errors: ["The super-emo-info attribute of type photos cannot be set during updates."]
+      });
     });
   });
 });


### PR DESCRIPTION
This update means that we'll only get the 422 error from update when you try to update a field that has the `@readOnly` attr set. if you try to update a field that doesnt have the `@readOnly` attr, then the server will just ignore the updated field.